### PR TITLE
correct exact matching method for columns that should be merged

### DIFF
--- a/R/DepluralizeDtm.R
+++ b/R/DepluralizeDtm.R
@@ -55,8 +55,8 @@ DepluralizeDtm <- function(dtm){
     sfLibrary(Matrix)
     
 	term.indices <- sfLapply( unique(colnames(changed)), function(x){ 	    
-        grep(x, colnames(changed), fixed=TRUE)
-        })
+        which(colnames(changed) == x)
+    })
 	
     sfStop()
     


### PR DESCRIPTION
grep(......, fixed = TRUE) != an exact match; it's a substring match. 

So in your version, foo would merge: foo, foos, wonderfoo, wonderfoos, foobar, foobars, footer, footers, etc.

which(.... == .....) provides the exact match you're looking for.