### PR TITLE
Ensure that stopwords and custom stopwords are lowercased 

### DIFF
--- a/R/Vec2Dtm.R
+++ b/R/Vec2Dtm.R
@@ -61,7 +61,10 @@ Vec2Dtm <- function(vec, min.n.gram=1, max.n.gram=1, remove.stopwords=TRUE,
     
     if( ! is.null(custom.stopwords) ) stopwords <- c(stopwords, custom.stopwords)
 	
-	if( lower ) vec <- tolower(vec)
+	if( lower ) {
+		vec <- tolower(vec)}
+		stopwords <- tolower(stopwords)
+	}
 	
 	if( remove.punctuation ){ 
 		vec <- gsub("[^a-zA-Z0-9]", " ", vec)


### PR DESCRIPTION
When lower = TRUE, both the vector of document texts AND the stopwords and custom stopwords should be lowercased (especially the custom stopwords, since they're user provided).