### PR TITLE
Cache model result

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,8 @@ Imports:
     RWeka,
     Rcpp,
     RcppProgress
+Suggests:
+    digest
 License: GPL (>= 3)
 URL: https://github.com/TommyJones/textmineR
 BugReports: https://github.com/TommyJones/textmineR/issues

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Below is a demo of some of the functionality in `textmineR`
     # fit some LDA models and select the best number of topics
     k_list <- seq(5, 50, by=5)
     
-    model_dir <- paste0("models_", digest::sha1(vocabulary))
+    model_dir <- paste0("models_", digest::digest(vocabulary, algo = "sha1"))
     
     if (!dir.exists(model_dir)) dir.create(model_dir)
     

--- a/README.md
+++ b/README.md
@@ -31,12 +31,24 @@ Below is a demo of some of the functionality in `textmineR`
     # fit some LDA models and select the best number of topics
     k_list <- seq(5, 50, by=5)
     
+    model_dir <- paste0("models_", digest::sha1(vocabulary))
+    
+    if (!dir.exists(model_dir)) dir.create(model_dir)
     
     model_list <- TmParallelApply(X = k_list, FUN = function(k){
-      m <- FitLdaModel(dtm = dtm, k = k, iterations = 500)
-      m$coherence <- apply(m$phi, 1, function(x) ProbCoherence(topic = x, dtm = dtm, M = 5))
+      filename = file.path(model_dir, paste0(k, "_topics.rda"))
+
+      if (!file.exists(filename)) {
+        m <- FitLdaModel(dtm = dtm, k = k, iterations = 500)
+        m$k <- k
+        m$coherence <- apply(m$phi, 1, function(x) ProbCoherence(topic = x, dtm = dtm, M = 5))
+        save(m, file = filename)
+      } else {
+        load(filename)
+      }
+      
       m
-    }, export=c("dtm")) # export only needed for Windows machines
+    }, export=c("dtm", "model_dir")) # export only needed for Windows machines
     
     coherence_mat <- data.frame(k=sapply(model_list, function(x) nrow(x$phi)), 
                                 coherence=sapply(model_list, function(x) mean(x$coherence)), stringsAsFactors=F)


### PR DESCRIPTION
Parallel generation of models is a computationally intensive task that, as it was coded, required complete success to return any result at all.

This update caches each model as it's generated and checks for prior model existence before computing a new model. That way, a user can safely restart model generation where only new computations will be performed.

As an additional benefit, partial results can be inspected while model generation is ongoing.

digest::digest is used to create a temporary directory name based on the vocabulary.