### PR TITLE
in case detectCores() will return NA as stated in the documentation.

### DIFF
--- a/R/TmParallelApply.R
+++ b/R/TmParallelApply.R
@@ -26,6 +26,7 @@ TmParallelApply <- function(X, FUN, cpus=parallel::detectCores(),
                             export=NULL, libraries=NULL, envir = parent.frame()){
   
   os <- .Platform$OS.type
+  if (length(cpus) == 0 || is.na(cpus)) cpus <- 1L
   
   if(os == "unix" ){ # on unix systems use mclapply()
     


### PR DESCRIPTION
as stated in the [documentation](https://stat.ethz.ch/R-manual/R-devel/library/parallel/html/detectCores.html) of detectCores(), direct usage to mcapply is highly not recommended which would potentially break the code. so I add one more check in the function just in case this would happen.
Thanks for ur review.
