### PR TITLE
Updated corpus_functions.R and topic_modeling_utilities.R w/ tibbles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,8 @@ Title: Functions for Text Mining and Topic Modeling
 Version: 3.0.5
 Authors@R: c(
     person("Tommy", "Jones", role = c("aut", "cre"), email = "jones.thos.w@gmail.com"),
-    person("William", "Doane", email = "wil@drdoane.com", role = "ctb")
+    person("William", "Doane", email = "wil@drdoane.com", role = "ctb"),
+    person("Mattias", "Attbom", email = "mattias1126@protonmail.com")
     )
 Description: An aid for text mining in R, with a syntax that
     should be familiar to experienced R users. Provides a wrapper for several 

--- a/R/corpus_functions.R
+++ b/R/corpus_functions.R
@@ -425,11 +425,12 @@ Dtm2Tcm <- function(dtm){
 #' returns a data frame with columns for term frequency, document frequency, 
 #' and inverse-document frequency
 #' @param dtm A document term matrix of class \code{dgCMatrix}.
-#' @return Returns a \code{data.frame} with 4 columns. The first column, 
-#' \code{term} is a vector of token labels. The second column, \code{term_freq}
-#' is the count of times \code{term} appears in the entire corpus. The third
-#' column \code{doc_freq} is the count of the number of documents in which 
-#' \code{term} appears. The fourth column, \code{idf} is the log-weighted
+#' @return Returns a \code{data.frame} or \code{tibble} with 4 columns.
+#' The first column, \code{term} is a vector of token labels.
+#' The second column, \code{term_freq} is the count of times \code{term}
+#' appears in the entire corpus. The third column \code{doc_freq} is the
+#' count of the number of documents in which \code{term} appears.
+#' The fourth column, \code{idf} is the log-weighted
 #' inverse document frequency of \code{term}.
 #' @export
 #' @examples
@@ -448,5 +449,9 @@ TermDocFreq <- function(dtm){
                          stringsAsFactors=FALSE)
   
   freq.mat$idf <- log(nrow(dtm) / freq.mat$doc_freq)
+
+  if ("tibble" %in% installed.packages()) {
+      freq.mat <- tibble::as_tibble(freq.mat)
+  }
   return(freq.mat)
 }

--- a/R/corpus_functions.R
+++ b/R/corpus_functions.R
@@ -450,7 +450,7 @@ TermDocFreq <- function(dtm){
   
   freq.mat$idf <- log(nrow(dtm) / freq.mat$doc_freq)
 
-  if ("tibble" %in% installed.packages()) {
+  if ("tibble" %in% row.names(installed.packages())) {
       freq.mat <- tibble::as_tibble(freq.mat)
   }
   return(freq.mat)

--- a/R/topic_modeling_utilities.R
+++ b/R/topic_modeling_utilities.R
@@ -3,7 +3,7 @@
 #' @param model A list (or S3 object) with three named matrices: phi, theta, and gamma.
 #'        These conform to outputs of many of \link[textmineR]{textmineR}'s native
 #'        topic modeling functions such as \link[textmineR]{FitLdaModel}. 
-#' @return An object of class \code{data.frame} with 6 columns: 'topic' is the 
+#' @return An object of class \code{data.frame} or \code{tibble} with 6 columns: 'topic' is the 
 #'         name of the topic, 'prevalence' is the rough prevalence of the topic 
 #'         in all documents across the corpus, 'coherence' is the probabilistic
 #'         coherence of the topic, 'top_terms_phi' are the top 5 terms for each
@@ -80,7 +80,11 @@ SummarizeTopics <- function(model){
                     top_terms_phi = tt_phi,
                     top_terms_gamma = tt_gamma,
                     stringsAsFactors = FALSE)
-  
+
+    if ("tibble" %in% row.names(installed.packages())) {
+        out <- tibble::as_tibble(out)
+    }
+ 
   out
 }
 
@@ -215,7 +219,7 @@ LabelTopics <- function(assignments, dtm, M=2){
 #' @description Takes topics by terms matrix and returns top M terms for each topic
 #' @param phi A matrix whose rows index topics and columns index words
 #' @param M An integer for the number of terms to return
-#' @return Returns a \code{data.frame} whose columns correspond to a topic and
+#' @return Returns a \code{data.frame} or \code{tibble} whose columns correspond to a topic and
 #' whose m-th row correspond to the m-th top term from the input \code{phi}.
 #' @export
 #' @examples
@@ -231,6 +235,10 @@ GetTopTerms <- function(phi, M){
   result <- apply(phi, 1, function(x){
     names(x)[ order(x, decreasing=TRUE) ][ 1:M ]
   })
+
+    if ("tibble" %in% row.names(installed.packages())) {
+        result <- tibble::as_tibble(result)
+    }
   
   return(result)
 }


### PR DESCRIPTION
This is more for the end-user as all we do is check if `tibble` is installed and if it is we use that for output instead of base-R. So internally `data.frame`s are still used.

Initial tests of in-place replacements of `data.frame` to `tibble` fails several unit-tests; this approach retains
backwards-compatability, and those who do not use `tibble` are also unaffected.

Depending on what you wanted to do with #68, this could either be closed, or this could be expanded on with a `switch` approach instead.