### PR TITLE
Remove obsolete CXX_STD = CXX11 to allow Armadillo 15.0.x migration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Description: An aid for text mining in R, with a syntax that
     topic models that take similarly-formatted input and give similarly-formatted
     output. Has additional functionality for analyzing and diagnostics for
     topic models.
-SystemRequirements: GNU make, C++11
+SystemRequirements: GNU make
 Depends:
     R (>= 3.0.2),
     Matrix


### PR DESCRIPTION
Armadillo 15.0.* now makes C++14 the minimum compilation standard. For most packages, adapting to it can be very simple, and yours is one of them. In this PR we simply remove the declaration from DESCRIPTION -- and no other changes are needed. (It is a bit unusual that you package has no `src/Makevars` and `src/Makevars.win` but you appear not to use LAPACK functions via Armadillo so all good, but see [here](https://github.com/RcppCore/RcppArmadillo/tree/master/inst/skeleton) for the reference pair.)

Please see issues [#475](https://github.com/RcppCore/RcppArmadillo/issues/475) and below for context, and notably [#489](https://github.com/RcppCore/RcppArmadillo/issues/489) for this first wave of PRs. It would be terrific if you could make an upload to CRAN 'soon' to remove the reliance on C++11 which we needed in the past, but which is by now a hindrance. Please do not hesitate to reach out if I can assist in any way or clarify matters.

/cc @kurthornik